### PR TITLE
clarify overwrite warning message;

### DIFF
--- a/src/pmotools/utils/small_utils.py
+++ b/src/pmotools/utils/small_utils.py
@@ -284,7 +284,7 @@ class Utils:
             raise Exception(
                 "Output file "
                 + output_file
-                + " already exists, use --overwrite to overwrite it"
+                + " already exists, use overwrite=T (or --overwrite if running from command line interface) to overwrite it"
             )
 
     @staticmethod


### PR DESCRIPTION
added a more clarifying warning message for the overwrite warning, resolves #62 