### PR TITLE
Update header name in script extract_allele_table

### DIFF
--- a/src/pmotools/scripts/pmo_to_tables/extract_allele_table.py
+++ b/src/pmotools/scripts/pmo_to_tables/extract_allele_table.py
@@ -91,7 +91,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--default_base_col_names",
         type=str,
         required=False,
-        default="library_sample_name,target_name,mhap_id",
+        default="library_sample_name,target_name,seq",
         help="default base column names, must be length 3",
     )
     return parser


### PR DESCRIPTION
default in the argparse was still mhap_id but we changed the default to be seq (it's changed to seq in the function itself, just not the script)